### PR TITLE
error fix for pg_trigger query & spelling typo

### DIFF
--- a/bin/pgcompacttable
+++ b/bin/pgcompacttable
@@ -494,7 +494,7 @@ sub has_triggers {
   WHERE
       tgrelid = '$ident_name'::regclass AND
       tgenabled IN ('A', 'R') AND
-      (tgtype & 16)::boolean");
+      (tgtype::integer & 16)::boolean");
   $sth->execute;
 
   if ($DBI::err) {

--- a/bin/pgcompacttable
+++ b/bin/pgcompacttable
@@ -1555,7 +1555,7 @@ foreach my $current_db_name (@dbs) {
       my $errstr = `ionice -c 3 -p $backend_pid 2>/dev/stdout`;
       if ($errstr) {
         chomp $errstr;
-        logger(LOG_WARNING, "Cannot set ionice 3 for the process. It is recomennded to set ionice -c 3 for pgcompacttable. Error: %s", $errstr);
+        logger(LOG_WARNING, "Cannot set ionice 3 for the process. It is recommended to set ionice -c 3 for pgcompacttable. Error: %s", $errstr);
       } else {
         $ionice_made = 1;
       }
@@ -1567,7 +1567,7 @@ foreach my $current_db_name (@dbs) {
   }
 
   unless ($ionice_made) {
-    logger(LOG_WARNING, "It is recomennded to set ionice -c 3 for pgcompacttable: ionice -c 3 -p %d", $backend_pid);
+    logger(LOG_WARNING, "It is recommended to set ionice -c 3 for pgcompacttable: ionice -c 3 -p %d", $backend_pid);
   }
 
   set_session_replication_role;


### PR DESCRIPTION
On 9.6 I was unable to run pgcompacttable without the casting tgtype to integer. You can't cast 16 to shortint because Pg doesn't know how to cast from smallint to boolean implicitly.

Also fixed a spelling typo that was bugging me :)