### PR TITLE
perform auto analyze after functional index creation

### DIFF
--- a/bin/pgcompacttable
+++ b/bin/pgcompacttable
@@ -732,7 +732,12 @@ SELECT
             (objid = indexoid AND classid = pgclassid) OR
             (refobjid = indexoid AND refclassid = pgclassid)
     )::integer AS allowed,
-    pg_catalog.pg_relation_size(indexoid)
+    (
+        SELECT string_to_array(indkey::text, ' ')::int2[] @> array[0::int2]
+        FROM pg_catalog.pg_index
+        WHERE indexrelid = indexoid
+    )::integer as is_functional,
+    pg_catalog.pg_relation_size(indexoid) as idxsize
 FROM (
     SELECT
         indexname, tablespace, indexdef,
@@ -751,7 +756,7 @@ FROM (
 ) AS sq
 LEFT JOIN pg_catalog.pg_constraint ON
     conindid = indexoid AND contype IN ('p', 'u')
-ORDER BY 8
+ORDER BY idxsize
  ");
   
   $sth->execute($schema_name, $table_name);
@@ -1016,11 +1021,27 @@ sub reindex_table {
       reindex($index_data);
 
       if($DBI::err) {
-        logger(LOG_NOTICE, "Skipping index %s: %s", $index_data->{indexname});
+        logger(LOG_NOTICE, "Skipping index %s: %s", $index_data->{indexname}, $DBI::err);
+        drop_temp_index($schema_name);
         next;
       }
 
       my $reindex_time = time - $start_reindex_time;
+
+      if ($index_data->{is_functional}) {
+        # perform auto analyze for functional indexes
+        my $analyze_time = time;
+        analyze($schema_name, $table_name);
+
+        if ($DBI::err) {
+          logger(LOG_ERROR, "Autoanalyze functional index error");
+          drop_temp_index($schema_name);
+          next;
+        }
+
+        $analyze_time = time - $analyze_time;
+        logger(LOG_NOTICE, "Autoanalyze functional index: duration %.3f second.", $analyze_time);
+      }
 
       my $locked_alter_attempt = 0;
       while ($locked_alter_attempt < LOCKED_ALTER_COUNT) {

--- a/bin/pgcompacttable
+++ b/bin/pgcompacttable
@@ -1021,7 +1021,7 @@ sub reindex_table {
       reindex($index_data);
 
       if($DBI::err) {
-        logger(LOG_NOTICE, "Skipping index %s: %s", $index_data->{indexname}, $DBI::err);
+        logger(LOG_NOTICE, "Skipping index %s: %s", $index_data->{indexname}, $DBI::errstr);
         drop_temp_index($schema_name);
         next;
       }


### PR DESCRIPTION
Recreating functional index will loose statistic and may be problem in production. Better is run analyze table after functional index create

This PR has common changes with pull request #10 and may conflict automerge. Please notify me after merge one of this two PR, i will merge manually and update pull request.